### PR TITLE
Add more constructor options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,16 +15,24 @@ class GCMClient extends EventEmitter {
    * @param options.senderId
    * @param options.apiKey
    */
-  constructor (senderId, apiKey) {
+  constructor (options) {
     super()
+    // Support old constructor signature of (senderId, apiKey).
+    let args = Array.prototype.slice.call(arguments, GCMClient.constructor.length);
+    if (args.length !== 1) {
+      options = {
+        senderId: args[0],
+        apiKey: args[1],
+      };
+    }
     this._acks = {}
     this._ackLimit = 100 // as per spec
     this._queue = async.queue(this._onQueueTask.bind(this), this._ackLimit)
     this._queue.pause()
 
     this._client = new xmpp.Client({
-      jid: senderId + '@gcm.googleapis.com',
-      password: apiKey,
+      jid: options.senderId + '@gcm.googleapis.com',
+      password: options.apiKey,
       port: 5235,
       reconnect: true,
       host: 'gcm.googleapis.com',

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,7 @@ class GCMClient extends EventEmitter {
         apiKey: args[1],
       };
     }
+    this._shouldAck = options.shouldAck || ((data) => true);
     this._acks = {}
     this._ackLimit = 100 // as per spec
     this._queue = async.queue(this._onQueueTask.bind(this), this._ackLimit)
@@ -116,7 +117,7 @@ class GCMClient extends EventEmitter {
 
         default:
           // Send ack, as per spec
-          if (data.from) {
+          if (data.from && this._shouldAck(data)) {
             this._send({
               to: data.from,
               message_id: data.message_id,

--- a/lib/client.js
+++ b/lib/client.js
@@ -33,7 +33,7 @@ class GCMClient extends EventEmitter {
     this._client = new xmpp.Client({
       jid: options.senderId + '@gcm.googleapis.com',
       password: options.apiKey,
-      port: 5235,
+      port: options.port || 5235,
       reconnect: true,
       host: 'gcm.googleapis.com',
       legacySSL: true,


### PR DESCRIPTION
The constructor now accepts an options object.

There are two new options: port and shouldAck. See the individual commits for details.
