### PR TITLE
Send an ACK in response to delivery receipt messages.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -111,10 +111,6 @@ class GCMClient extends EventEmitter {
           }
           break
 
-        case 'receipt':
-          this.emit('receipt', data.message_id, data.from, data.category, data.data)
-          break
-
         default:
           // Send ack, as per spec
           if (data.from && this._shouldAck(data)) {
@@ -125,7 +121,8 @@ class GCMClient extends EventEmitter {
             })
 
             if (data.data) {
-              this.emit('message', data.message_id, data.from, data.category, data.data)
+              let event = data.message_type === 'receipt' ? 'receipt' : 'message';
+              this.emit(event, data.message_id, data.from, data.category, data.data)
             }
           }
           break


### PR DESCRIPTION
Per the docs at
https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref#ccs,
an ack is required for these messages.